### PR TITLE
用imageio库读取图片，增加灰度映射功能

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 #!/usr/bin/env -S pip install -r
 
+imageio
 # installing wxpython will install numpy
 # numpy
 piexif
 pillow>=9.3
 wxpython
-imageio

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@
 piexif
 pillow>=9.3
 wxpython
+imageio

--- a/src/mulimgviewer/gui/main_gui.py
+++ b/src/mulimgviewer/gui/main_gui.py
@@ -583,6 +583,33 @@ class MulimgViewerGui ( wx.Frame ):
 
 
 		fgSizer3.Add( wSizer10, 1, wx.EXPAND, 5 )
+######
+		self.m_staticline23 = wx.StaticLine( self.m_panel4, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, wx.LI_HORIZONTAL )
+		fgSizer3.Add( self.m_staticline23, 0, wx.EXPAND |wx.ALL, 5 )
+
+		wSizer12 = wx.WrapSizer( wx.HORIZONTAL, wx.WRAPSIZER_DEFAULT_FLAGS )
+
+		self.m_staticText42 = wx.StaticText( self.m_panel4, wx.ID_ANY, u"Value", wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.m_staticText42.Wrap( -1 )
+
+		self.m_staticText42.SetFont( wx.Font( 12, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False, wx.EmptyString ) )
+
+		wSizer12.Add( self.m_staticText42, 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 5 )
+
+		self.m_staticline24 = wx.StaticLine( self.m_panel4, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, wx.LI_VERTICAL )
+		wSizer12.Add( self.m_staticline24, 0, wx.EXPAND |wx.ALL, 5 )
+
+		self.m_staticText43 = wx.StaticText( self.m_panel4, wx.ID_ANY, u"Range", wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.m_staticText43.Wrap( -1 )
+
+		wSizer12.Add( self.m_staticText43, 1, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 5 )
+
+		self.img_value_range = wx.TextCtrl( self.m_panel4, wx.ID_ANY, u"0,255", wx.DefaultPosition, wx.Size( 80,-1 ), 0 )
+		wSizer12.Add( self.img_value_range, 1, wx.ALL, 5 )
+
+
+		fgSizer3.Add( wSizer12, 1, wx.EXPAND, 5 )
+######
 
 		self.m_staticline7 = wx.StaticLine( self.m_panel4, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, wx.LI_HORIZONTAL )
 		fgSizer3.Add( self.m_staticline7, 0, wx.EXPAND |wx.ALL, 5 )

--- a/src/mulimgviewer/src/main.py
+++ b/src/mulimgviewer/src/main.py
@@ -1021,8 +1021,8 @@ class MulimgViewer (MulimgViewerGui):
                     magnifier_out_scale,                    # 31
                     self.customfunc.Value,                  # 32
                     self.out_path_str,                      # 33
-                    img_value_range,                        # 34    
-                    ]                      
+                    img_value_range,                        # 34
+                    ]
 
 
     def show_img(self):

--- a/src/mulimgviewer/src/main.py
+++ b/src/mulimgviewer/src/main.py
@@ -926,6 +926,9 @@ class MulimgViewer (MulimgViewerGui):
                 0).split(',')
             magnifier_out_scale = [float(x) for x in magnifier_out_scale]
 
+            img_value_range = self.img_value_range.GetLineText(0).split(',')
+            img_value_range = [int(x) for x in img_value_range]
+
             if self.checkBox_auto_draw_color.Value:
                 # 10 colors built into the software
                 color_list = [
@@ -1017,7 +1020,10 @@ class MulimgViewer (MulimgViewerGui):
                     self.onetitle.Value,                    # 30
                     magnifier_out_scale,                    # 31
                     self.customfunc.Value,                  # 32
-                    self.out_path_str]                      # 33
+                    self.out_path_str,                      # 33
+                    img_value_range,                        # 34    
+                    ]                      
+
 
     def show_img(self):
         if self.customfunc.Value and self.out_path_str == "":

--- a/src/mulimgviewer/src/utils_img.py
+++ b/src/mulimgviewer/src/utils_img.py
@@ -579,7 +579,12 @@ class ImgManager(ImgData):
             if path.is_file() and path.suffix.lower() in self.format_group:
                 img = imageio.imread(path)
                 if img.dtype != np.uint8:
-                    img = (255 * img).astype(np.uint8)
+                    img = np.around(255 * img).astype(np.uint8)
+                img_value_range=np.array(self.layout_params[34])
+                vmin=img_value_range.min()
+                vmax=img_value_range.max()
+                if (vmin != 0 or vmax != 255) and vmin < vmax:
+                    img=((np.clip(img,vmin,vmax)-vmin) / (vmax-vmin) * 255).astype(np.uint8)
                 pil_img = Image.fromarray(img)
                 img_list.append(pil_img.convert('RGB'))
                 # img_list.append(Image.open(path).convert('RGB'))

--- a/src/mulimgviewer/src/utils_img.py
+++ b/src/mulimgviewer/src/utils_img.py
@@ -9,6 +9,7 @@ import numpy as np
 import piexif
 import wx
 from PIL import Image, ImageDraw, ImageFont
+import imageio
 
 from .data import ImgData
 from .utils import rgb2hex
@@ -576,7 +577,12 @@ class ImgManager(ImgData):
             path = Path(path)
             name_list.append(path.name)
             if path.is_file() and path.suffix.lower() in self.format_group:
-                img_list.append(Image.open(path).convert('RGB'))
+                img = imageio.imread(path)
+                if img.dtype != np.uint8:
+                    img = (255 * img).astype(np.uint8)
+                pil_img = Image.fromarray(img)
+                img_list.append(pil_img.convert('RGB'))
+                # img_list.append(Image.open(path).convert('RGB'))
             else:
                 pass
         # custom process


### PR DESCRIPTION
1，原来用PIL读取图片，无法处理浮点值的.tif格式图片，用imageio可以解决。
2，有些图片对比度低，需要重新映射灰度值，类似matplot.plot(vmin= , vmax= )这个功能