### PR TITLE
FIx issue#151:Automatically refresh before saving to apply output format changes

### DIFF
--- a/src/mulimgviewer/src/main.py
+++ b/src/mulimgviewer/src/main.py
@@ -233,6 +233,9 @@ class MulimgViewer (MulimgViewerGui):
         self.SetStatusText_(["Skip", "-1", "-1", "-1"])
 
     def save_img(self, event):
+        if self.ImgManager.img_num != 0:
+            self.show_img_init()
+            self.show_img()
         type_ = self.choice_output.GetSelection()
         if self.auto_save_all.Value:
             last_count_img = self.ImgManager.action_count


### PR DESCRIPTION
## 问题描述
issue151：修改文件输出格式应不需要刷新即可生效

## 解决方案
在保存操作前自动执行刷新，确保输出格式更改立即生效

## 修改内容
在 `src/mulimgviewer/src/main.py` 的 `save_img` 方法开头添加了自动刷新逻辑：

```python
# 在保存前先自动刷新，确保使用最新设置
if self.ImgManager.img_num != 0:
    self.show_img_init()
    self.show_img()