### PR TITLE
Issue #151 修复：修改文件输出格式无需刷新即可生效

### DIFF
--- a/src/mulimgviewer/src/main.py
+++ b/src/mulimgviewer/src/main.py
@@ -231,6 +231,10 @@ class MulimgViewer (MulimgViewerGui):
 
     def save_img(self, event):
         type_ = self.choice_output.GetSelection()
+        save_format = self.save_format.GetSelection()
+        if hasattr(self, 'ImgManager') and hasattr(self.ImgManager, 'layout_params'):
+            if len(self.ImgManager.layout_params) > 35:
+                self.ImgManager.layout_params[35] = save_format
         if self.auto_save_all.Value:
             last_count_img = self.ImgManager.action_count
             self.ImgManager.set_action_count(0)


### PR DESCRIPTION
## 问题描述
在 MulimgViewer 中，当用户更改文件输出格式（PNG/PDF/JPG）时，需要刷新界面才能使设置生效。这与输出模式（stitch/select/magnifer等）的行为不一致，后者可以立即生效。
## 根本原因
在 main.py 的 save_img 方法中：
正确获取了输出模式：type_ = self.choice_output.GetSelection()
但没有获取当前的保存格式设置并传递给底层的 ImgManager
## 修改内容
在 save_img 方法开头添加代码，获取当前保存格式并更新到 ImgManager 的参数中：
``` python
def save_img(self, event):
    type_ = self.choice_output.GetSelection()
    # 新增：获取当前保存格式设置
    save_format = self.save_format.GetSelection()
    
    # 确保layout_params中的保存格式是最新的
    if hasattr(self, 'ImgManager') and hasattr(self.ImgManager, 'layout_params'):
        if len(self.ImgManager.layout_params) > 35:
            self.ImgManager.layout_params[35] = save_format
    
