### PR TITLE
bug：Fix the issue where scrollbars do not appear when images exceed the window display area

### DIFF
--- a/src/mulimgviewer/src/main.py
+++ b/src/mulimgviewer/src/main.py
@@ -1610,6 +1610,9 @@ class MulimgViewer (MulimgViewerGui):
                 self.SetStatusText_(["-1", "-1", detail_text, "-1"])
             except:
                 self.SetStatusText_(["-1", "-1", f"{self.ImgManager.img_resolution[0]}x{self.ImgManager.img_resolution[1]} pixels", "-1"])
+        # Defer layout refresh to avoid forcing window resize while still updating scrollbars
+        wx.CallAfter(self.scrolledWindow_img.FitInside)
+        wx.CallAfter(self.Layout)
 
     def auto_layout(self, frame_resize=False):
         # Auto Layout


### PR DESCRIPTION
## bug：
When the software is launched for the first time, if the image exceeds the window display area without changing the window size, **the scrollbar will not appear**.
<img width="453.6" height="343,8" alt="6eff94b048da92f89143cd9427687960" src="https://github.com/user-attachments/assets/40f2990e-1786-46c0-b1ec-7e678366933e" />
## Solution
Add wx.CallAfter(self.scrolledWindow_img.FitInside) and wx.CallAfter(self.Layout) at the end of the show_img method to perform a deferred refresh.
<img width="359.1" height="55.8" alt="image" src="https://github.com/user-attachments/assets/d1f9ebef-be49-410b-a976-202dc31f13b0" />
