### PR TITLE
bug：Fix AutoWinSize button responsiveness in layout

### DIFF
--- a/src/mulimgviewer/src/main.py
+++ b/src/mulimgviewer/src/main.py
@@ -1610,9 +1610,13 @@ class MulimgViewer (MulimgViewerGui):
                 self.SetStatusText_(["-1", "-1", detail_text, "-1"])
             except:
                 self.SetStatusText_(["-1", "-1", f"{self.ImgManager.img_resolution[0]}x{self.ImgManager.img_resolution[1]} pixels", "-1"])
-        # Defer layout refresh to avoid forcing window resize while still updating scrollbars
-        wx.CallAfter(self.scrolledWindow_img.FitInside)
-        wx.CallAfter(self.Layout)
+        # Fix the issue where the AutoWinSize button is unresponsive
+        if self.auto_layout_check.Value:
+            self.auto_layout()
+        else:
+            # Defer layout refresh to avoid forcing window resize while still updating scrollbars
+            wx.CallAfter(self.scrolledWindow_img.FitInside)
+            wx.CallAfter(self.Layout)
 
     def auto_layout(self, frame_resize=False):
         # Auto Layout


### PR DESCRIPTION
## bug：the AutoWinSize button is unresponsive
## Solution: Add an if judgment at the end of the show_img function, as shown in the figure
<img width="1431" height="416" alt="4c5911ce00c412f08f9e21ea94aba9aa" src="https://github.com/user-attachments/assets/782fbc3d-090c-4de3-a033-94b1e97ad3e6" />
