### PR TITLE
Fix issue167:disable mouse wheel in unexpanded option bars (#163)

### DIFF
--- a/src/mulimgviewer/src/main.py
+++ b/src/mulimgviewer/src/main.py
@@ -133,6 +133,7 @@ class MulimgViewer (MulimgViewerGui):
         self.custom_algorithms = []
         # self.refresh_algorithm_list()
         self.load_configuration( None , config_name="output.json")
+        self._bind_settings_wheel_guard()
 
     def EVT_MY_TEST_OnHandle(self, event):
         self.about_gui(None, update=True, new_version=event.GetEventArgs())
@@ -1846,6 +1847,47 @@ class MulimgViewer (MulimgViewerGui):
         # issue: You need to change the window size, then the scrollbar starts to display.
         self.scrolledWindow_set.FitInside()
         self.auto_layout()
+
+    def _bind_settings_wheel_guard(self):
+        swallow_types = (wx.Choice, wx.ComboBox, wx.SpinCtrl, wx.SpinCtrlDouble)
+
+        def mark_popup_open(event):
+            obj = event.GetEventObject()
+            setattr(obj, "_popup_open", True)
+            event.Skip()
+
+        def mark_popup_closed(event):
+            obj = event.GetEventObject()
+            setattr(obj, "_popup_open", False)
+            event.Skip()
+
+        def reroute_wheel(event):
+            obj = event.GetEventObject()
+            if getattr(obj, "_popup_open", False):
+                event.Skip()
+                return
+            clone = event.Clone()
+            clone.SetEventObject(self.scrolledWindow_set)
+            clone.ResumePropagation(wx.EVENT_PROPAGATE_MAX)
+            self.scrolledWindow_set.GetEventHandler().ProcessEvent(clone)
+
+        def walk(win):
+            for child in win.GetChildren():
+                if isinstance(child, swallow_types):
+                    setattr(child, "_popup_open", False)
+                    child.Bind(wx.EVT_MOUSEWHEEL, reroute_wheel)
+                    if isinstance(child, wx.Choice):
+                        child.Bind(wx.EVT_LEFT_DOWN, mark_popup_open)
+                        child.Bind(wx.EVT_CHOICE, mark_popup_closed)
+                        child.Bind(wx.EVT_KILL_FOCUS, mark_popup_closed)
+                    elif isinstance(child, wx.ComboBox):
+                        child.Bind(wx.EVT_LEFT_DOWN, mark_popup_open)
+                        child.Bind(wx.EVT_COMBOBOX, mark_popup_closed)
+                        child.Bind(wx.EVT_KILL_FOCUS, mark_popup_closed)
+                if child.GetChildren():
+                    walk(child)
+
+        walk(self.scrolledWindow_set)
 
     def save_configuration(self, event):
         data = {


### PR DESCRIPTION
## Fixes
Closes #167

## Problem
When scrolling the software's edit bar with the mouse wheel, the mouse easily slips into an unexpanded option bar (e.g., wx.Choice, wx.ComboBox). This causes unintended parameter changes in the option bar and interrupts the scrolling of the edit bar page.

## Solution
Make the mouse wheel only take effect in **expanded option bars**; redirect wheel events from unexpanded option bars to the settings scroll window (`scrolledWindow_set`).

## Implementation Details
1. Define target option bar controls: `wx.Choice`, `wx.ComboBox`, `wx.SpinCtrl`, `wx.SpinCtrlDouble` (swallow_types).
2. Add a dynamic state `_popup_open` to controls to mark whether the option bar is expanded.
3. Bind `EVT_LEFT_DOWN`/`EVT_CHOICE`/`EVT_KILL_FOCUS` events to update the `_popup_open` state (mark open/closed).
4. Rewrite wheel event logic (`reroute_wheel`):
   - If the option bar is expanded (`_popup_open=True`): Let the control handle the wheel event normally.
   - If unexpanded (`_popup_open=False`): Redirect the wheel event to the settings scroll window to ensure the edit bar scrolls continuously.
5. Recursively traverse the control tree via `walk()` to bind events for all target controls in `scrolledWindow_set`.

## Testing
- Verify that wheel scrolling on unexpanded option bars no longer changes parameters and the edit bar scrolls normally.